### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,7 @@
     "email": "boyan@rabchev.com",
     "url": "https://github.com/rabchev/brackets-server/issues"
   },
-  "license": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "engines": {
     "node": ">=0.10"
   }


### PR DESCRIPTION
The license value in the package.json should be a valid SPDX as documented on (https://docs.npmjs.com/files/package.json#license). This commit fixes it.